### PR TITLE
Begin prototyping plugin invocation

### DIFF
--- a/pkg/kubectl/cmd/plugin.go
+++ b/pkg/kubectl/cmd/plugin.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -43,30 +42,14 @@ var (
 
 // NewCmdPlugin creates the command that is the top-level for plugin commands.
 func NewCmdPlugin(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	// Loads plugins and create commands for each plugin identified
-	loadedPlugins, loadErr := pluginLoader().Load()
-	if loadErr != nil {
-		glog.V(1).Infof("Unable to load plugins: %v", loadErr)
-	}
-
 	cmd := &cobra.Command{
 		Use: "plugin NAME",
 		DisableFlagsInUseLine: true,
 		Short: i18n.T("Runs a command-line plugin"),
 		Long:  plugin_long,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(loadedPlugins) == 0 {
-				cmdutil.CheckErr(fmt.Errorf("no plugins installed."))
-			}
 			cmdutil.DefaultSubCommandRun(streams.ErrOut)(cmd, args)
 		},
-	}
-
-	if len(loadedPlugins) > 0 {
-		pluginRunner := pluginRunner()
-		for _, p := range loadedPlugins {
-			cmd.AddCommand(NewCmdForPlugin(f, p, pluginRunner, streams))
-		}
 	}
 
 	return cmd


### PR DESCRIPTION
Opening here first to generate some discussion about implementation details.

With the current design, a user is able to place an executable file anywhere on their PATH.
A search is performed based on the command line arguments given by the user.
For a path `kubectl plugin foo`, for example, we:

1. search to see if the subcommand "plugin" exists.
  - if "plugin" exists, we lookup its annotations to see if it is marked as "can-be-extended"
  - if "plugin" does not exist, `kubectl` cannot be "extended", therefore, we treat that as a "command-not-found" error always.
2. search to see if subcommand "foo" exists.
  - if "foo" exists, we lookup its annotations to see if it is marked as "can-be-extended"
  - if "foo" does not exist, we check to see if its parent was marked as "can-be-extended"
    - if `foo`'s parent was marked as "can-be-extended", we attempt to look for the executable `kubectl-plugin-foo` [3] (`kubectl-plugin-foo.exe` on windows) [2] in the user's PATH.
      - if the executable (`kubectl-plugin-foo`) is not found in the user's PATH, we exit with error [1].
    - if `foo`'s parent was not marked as "can-be-extended",  we exit with error [1].

1. 
```
error: unknown command "foo"
See 'kubectl plugin -h' for help and examples.
```
2. Note that the binary's name is not bound to `kubectl-plugin-...`, if we were writing a plugin for "create", for example, we would look for a binary `kubectl-create-foo`
3. Also note that the current implementation looks for the longest possible binary in the user's path that it can find. For example, if a user specifies `kubectl plugin foo bar baz`, and the user's PATH contains two binaries (`kubectl-plugin-foo`, and `kubectl-plugin-foo-bar-baz`), then `kubectl-plugin-foo-bar-baz` would always be executed.

cc @deads2k @soltysh @mfojtik